### PR TITLE
install flow, only run flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM node:6.9.4
+FROM meetup/node-yarn:7.5.0-0.20.3
 
 RUN rm -rf /var/lib/apt/lists/* \
   && apt-get update \
   && apt-get install -y ocaml libelf-dev \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && yarn global add flow-bin@0.39.0
+
+VOLUME /app
+WORKDIR /app
+
+CMD [ "flow" ]


### PR DESCRIPTION
For use in conjunction with https://github.com/meetup/web-platform-starter/pull/147 

this allows `pro-web` to use `meetup/node-yarn:7.5.0-0.20.3` and run flow from a separate docker image. 

additional PRs needed:

add `flow` make target to `web-platform-starter`: 
`docker run -it -v $(CI_WORKDIR):/app meetup/node-flow:0.39`

pull into downstream repos

and then 

`pro-web` adds `flow` to `prepackage` target which is currently empty. and removes `flow` from `npm run package`

---

the version of this image should match the flow version

---
I'm happy to talk this over. Sorry if my notes are confusing. I think the end result will be nice and simple.