### PR TITLE
Updates to Node, Flow and versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will
 be documented in this file.
 
+## [0.40.0-0.0.x]
+### Added
+- New versioning in form of `node-flow:FLOW_VERSION-BUILD_VERSION`
+- Updated `node` to `v7.7.1`
+- Updated `flow-bin` to `v0.40.0`
+- No longer using the custom `meetup/node-yarn` container. `node:7.7.1` has Yarn built in.
+
 ## [0.39.0]
 ### Added
 - Based on Node v7.5.0.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM meetup/node-yarn:7.5.0-0.20.3
+FROM node:7.7.1
 
 RUN rm -rf /var/lib/apt/lists/* \
   && apt-get update \
   && apt-get install -y ocaml libelf-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  && yarn global add flow-bin@0.39.0
+  && yarn global add flow-bin@0.40.0
 
 VOLUME /app
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 PROJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CI_BUILD_NUMBER ?= $(USER)-snapshot
 
-VERSION ?= 0.39.0
+VERSION ?= 0.0.$(CI_BUILD_NUMBER)
+FLOW_VERSION ?= 0.40.0
 
-PUBLISH_TAG=meetup/node-flow:$(VERSION)
+PUBLISH_TAG=meetup/node-flow:$(FLOW_VERSION)-$(VERSION)
 
 # lists all available targets
 list:


### PR DESCRIPTION
- Node update to 7.7.1
- Flow update to 0.40.0
- Versioning updated to `flow version`-`build version` so changes can be made to this repo and versioned independently from the version of flow

Addresses the following issues:
- https://github.com/meetup/node-flow/issues/5
- https://github.com/meetup/node-flow/issues/6