### PR TITLE
fix github tags/releases version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,6 @@ after_success:
     [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] &&
     git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags || true
   # Trigger microbadger to update badges
-  - curl -d "" https://hooks.microbadger.com/images/meetup/node-flow/NVNBp6UszPv1NzVIfEJz8FJPrHE\=
+  - >
+    [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] &&
+    curl -d "" https://hooks.microbadger.com/images/meetup/node-flow/NVNBp6UszPv1NzVIfEJz8FJPrHE\= || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,5 @@ after_success:
   - >
     [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] &&
     git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags || true
+  # Trigger microbadger to update badges
+  - curl -d "" https://hooks.microbadger.com/images/meetup/node-flow/NVNBp6UszPv1NzVIfEJz8FJPrHE\=

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ publish: package
 	@docker push $(PUBLISH_TAG)
 
 version:
-	@echo $(VERSION)
+	@echo $(FLOW_VERSION)-$(VERSION)
 
 publish-tag:
 	@echo $(PUBLISH_TAG)


### PR DESCRIPTION
Previously was just the `build version`, now it will be `flow version`-`build version` to match the version on docker hub